### PR TITLE
Do not create loadorder.txt when initializing profile

### DIFF
--- a/src/gameskyrim.cpp
+++ b/src/gameskyrim.cpp
@@ -113,7 +113,6 @@ void GameSkyrim::initializeProfile(const QDir &path, ProfileSettings settings) c
 {
   if (settings.testFlag(IPluginGame::MODS)) {
     copyToProfile(localAppFolder() + "/Skyrim", path, "plugins.txt");
-    copyToProfile(localAppFolder() + "/Skyrim", path, "loadorder.txt");
   }
 
   if (settings.testFlag(IPluginGame::CONFIGURATION)) {

--- a/src/gameskyrim.cpp
+++ b/src/gameskyrim.cpp
@@ -99,7 +99,7 @@ QString GameSkyrim::description() const
 
 MOBase::VersionInfo GameSkyrim::version() const
 {
-  return VersionInfo(1, 5, 0, VersionInfo::RELEASE_FINAL);
+  return VersionInfo(1, 6, 0, VersionInfo::RELEASE_FINAL);
 }
 
 QList<PluginSetting> GameSkyrim::settings() const


### PR DESCRIPTION
The original intention behind loadorder.txt is to simply report the
load order of plugins to other applications. If the file is not a
known, good load order from MO2, it should not be used to change
the load order.